### PR TITLE
support for admin_server option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Attributes
  * `krb5['default_realm']` - The default realm, defaults to OHAI's domain attribute.
  * `krb5['realms']` - Array of all realms, including the default.  Defaults to OHAI's domain attribute.
  * `krb5['default_realm_kdcs']` - Array of Kerberos servers, this is optional, and default empty.  
+ * `krb5['default_realm_admin_server']` - Kerberos admin server, this is optional, and default empty
  * `krb5['lookup_kdcs']` - Set to true if you have SRV records for KDC discovery.  Default is true.
  * `krb5['default_logging']` - Default log location.  Default, 'FILE:/var/log/krb5libs.log'
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,6 +37,7 @@ default['krb5']['default_logging'] = 'FILE:/var/log/krb5libs.log'
 default['krb5']['default_realm'] = node['domain']
 default['krb5']['realms'] = [node['domain']]
 default['krb5']['default_realm_kdcs'] = []
+default['krb5']['default_realm_admin_server'] = ''
 default['krb5']['lookup_kdc'] = 'true'
 default['krb5']['ticket_lifetime'] = '24h'
 default['krb5']['renew_lifetime'] = '24h'

--- a/templates/default/krb5.conf.erb
+++ b/templates/default/krb5.conf.erb
@@ -14,11 +14,14 @@
  forwardable = <%= node['krb5']['forwardable'] %>
 
 [realms]
- <% unless node['krb5']['default_realm_kdcs'].empty? -%>
+ <% unless node['krb5']['default_realm_kdcs'].empty? && node['krb5']['default_realm_admin_server'].empty? -%>
  <%= node['krb5']['default_realm'].upcase %> = {
   <% node['krb5']['default_realm_kdcs'].each do |kdc_server| -%>
   kdc = <%= kdc_server %>
   <% end -%>
+  <% unless node['krb5']['default_realm_admin_server'].empty? -%>
+  admin_server = <%=  node['krb5']['default_realm_admin_server'] %>
+  <% end %>
  }
  <% end -%>
 


### PR DESCRIPTION
adding an optional attribute ['krb5']['default_realm_admin_server'] which will allow you to add the "admin_server" tag to the default realm section.  This provides configuration necessary to run kadmin commands against a remote administration server.

example input:

```
      :krb5 => {
        "default_realm" => "example.com",
        "default_realm_admin_server" => "kdc1.example.com",
        "default_realm_kdcs" => [
          "kdc1.example.com",
          "kdc2.example.com",
          "kdc3.example.com"
        ]
      }
```

example output:

```
[realms]
 EXAMPLE.COM = {
  kdc = kdc1.example.com
  kdc = kdc2.example.com
  kdc = kdc3.example.com
  admin_server = kdc1.example.com
 }
```
