### PR TITLE
Check for empty, not nil, admin_server attribute

### DIFF
--- a/templates/default/krb5.conf.erb
+++ b/templates/default/krb5.conf.erb
@@ -24,7 +24,7 @@
   <% node['krb5']['krb5_conf']['realms']['default_realm_kdcs'].each do |kdc_server| -%>
   kdc = <%= kdc_server %>
   <% end -%>
-  <% unless node['krb5']['krb5_conf']['realms']['default_realm_admin_server'].nil? -%>
+  <% unless node['krb5']['krb5_conf']['realms']['default_realm_admin_server'].empty? -%>
   admin_server = <%=  node['krb5']['krb5_conf']['realms']['default_realm_admin_server'] %>
   <% end %>
  }


### PR DESCRIPTION
This was causing the line `admin-server =` to be put in krb5.conf. And yikes, looks like it will lock everyone out on ubuntu 14.04
