### PR TITLE
LWRP for principals and keytabs

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,6 +19,7 @@
 # limitations under the License.
 #
 
+# Platform-specific configuration
 case node['platform_family']
 when 'rhel'
   default['krb5']['packages'] = %w(krb5-libs krb5-workstation pam pam_krb5 authconfig)
@@ -48,6 +49,8 @@ else
   default['krb5']['kdc']['packages'] = []
 end
 
+# TODO: deprecate these for future removal
+# Legacy attributes
 default['krb5']['default_logging'] = 'FILE:/var/log/krb5libs.log'
 default['krb5']['default_realm'] = node['domain'].upcase
 default['krb5']['realms'] = [node['domain']]
@@ -66,6 +69,9 @@ default_realm =
   else
     'LOCAL'
   end
+
+# Default location for keytabs generated from LWRP
+default['krb5']['keytabs_dir'] = '/etc/security/keytabs'
 
 # Client Packages
 default['krb5']['client']['packages'] = node['krb5']['packages']

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,6 +30,7 @@ when 'rhel'
   default['krb5']['kadmin']['packages'] = %w(krb5-server)
   default['krb5']['kdc']['service_name'] = 'krb5kdc'
   default['krb5']['kdc']['packages'] = %w(krb5-server krb5-server-ldap)
+  default['krb5']['devel']['packages'] = %w(krb5-devel)
 when 'debian'
   default['krb5']['packages'] = %w(libpam-krb5 libpam-runtime libkrb5-3 krb5-user)
   default['krb5']['authconfig'] = 'pam-auth-update --package krb5'
@@ -39,6 +40,7 @@ when 'debian'
   default['krb5']['kadmin']['packages'] = %w(krb5-admin-server)
   default['krb5']['kdc']['service_name'] = 'krb5-kdc'
   default['krb5']['kdc']['packages'] = %w(krb5-kdc krb5-kdc-ldap)
+  default['krb5']['devel']['packages'] = %w(libkrb5-dev)
 when 'suse'
   default['krb5']['packages'] = %w(krb5 pam_krb5 pam-config)
   default['krb5']['authconfig'] = 'pam-config --add --krb5'
@@ -47,6 +49,7 @@ else
   default['krb5']['authconfig'] = ''
   default['krb5']['kadmin']['packages'] = []
   default['krb5']['kdc']['packages'] = []
+  default['krb5']['devel']['packages'] = []
 end
 
 # TODO: deprecate these for future removal

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -47,6 +47,22 @@ module Krb5
     def krb5_verify_admin
       Chef::Application.fatal!("You must specify both node['krb5']['admin_principal'] and node['krb5']['admin_password']!") if !node['krb5']['admin_principal'] || !node['krb5']['admin_password']
     end
+
+    # Acquire credentials for principal from keytab using service
+    # Parent method: #get_init_creds_keytab(principal = nil, keytab = nil, service = nil, ccache = nil)
+    # If no principal, derive from service... If no service, defaults to "host"... If no keytab, defaults to "/etc/krb5.keytab"
+    #
+    # @result Object
+    def krb5_kinit_keytab(principal, keytab)
+      Kerberos::Krb5.get_init_creds_keytab(principal, keytab)
+    end
+
+    # Acquire credentials for user using password
+    #
+    # @result Object
+    def krb5_kinit_password(user, password)
+      Kerberos::Krb5.get_init_creds_password(user, password)
+    end
   end
 end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -70,7 +70,7 @@ module Krb5
     def krb5_load_gem
       require 'rkerberos'
     rescue LoadError
-      Chef::Log.error("Missing gem 'rkerberos'. Use the 'rkerberos_gem' recipe to install it first.")
+      Chef::Application.fatal!("Missing gem 'rkerberos'. Use the 'rkerberos_gem' recipe to install it first.")
     end
 
     # Search for a principal in a keytab

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -79,7 +79,7 @@ module Krb5
     def keytab_find_principal(keytab, principal)
       keytab.get_entry(principal)
     rescue Krb5::Keytab::Exception
-      nil
+      return nil
     end
 
     # Search for a principal on a KDC
@@ -88,7 +88,7 @@ module Krb5
     def kadm5_find_principal(kadm5, principal)
       kadm5.get_principal(principal)
     rescue Kerberos::Kadm5::PrincipalNotFoundException
-      nil
+      return nil
     end
 
     # Converts principals array to a string

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -87,7 +87,7 @@ module Krb5
     # @result [Object, nil]
     def kadm5_find_principal(kadm5, principal)
       kadm5.get_principal(principal)
-    rescue PrincipalNotFoundException
+    rescue Kerberos::Krb5::PrincipalNotFoundException
       nil
     end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -86,12 +86,7 @@ module Krb5
     #
     # @result [Object, nil]
     def kadm5_find_principal(kadm5, principal)
-      if principal =~ /@/
-        # Given principal includes realm
-        kadm5.get_principal(principal)
-      else
-        kadm5.get_principal("principal@#{krb5_default_realm}")
-      end
+      kadm5.get_principal(principal)
     rescue Kerberos::Kadm5::PrincipalNotFoundException
       return nil
     end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -121,7 +121,3 @@ module Krb5
     end
   end
 end
-
-Chef::Recipe.send(:include, ::Krb5::Helpers)
-Chef::Resource.send(:include, ::Krb5::Helpers)
-Chef::Provider.send(:include, ::Krb5::Helpers)

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -45,9 +45,7 @@ module Krb5
 
     # Verify admin credentials are passed
     def krb5_verify_admin
-      if !node['krb5']['admin_principal'] || !node['krb5']['admin_password']
-        Chef::Application.fatal!("You must specify both node['krb5']['admin_principal'] and node['krb5']['admin_password']!")
-      end
+      Chef::Application.fatal!("You must specify both node['krb5']['admin_principal'] and node['krb5']['admin_password']!") if !node['krb5']['admin_principal'] || !node['krb5']['admin_password']
     end
   end
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -1,0 +1,57 @@
+#
+# Cookbook Name:: krb5
+# Library:: helpers
+#
+# Copyright © 2014 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# require 'rkerberos'
+
+module Krb5
+  # Helpers for Krb5
+  module Helpers
+    # Initialize Kadm5
+    #
+    # @return Object
+    def kadm5_init(principal, password)
+      Kerberos::Kadm5.new(:principal => principal, :password => password)
+    end
+
+    # Initialize Krb5
+    #
+    # @return Object
+    def krb5_init
+      Kerberos::Krb5.new
+    end
+
+    # Initialize Keytab
+    #
+    # @return Object
+    def keytab_init
+      Kerberos::Krb5::Keytab.new
+    end
+
+    # Verify admin credentials are passed
+    def krb5_verify_admin
+      if !node['krb5']['admin_principal'] || !node['krb5']['admin_password']
+        Chef::Application.fatal!("You must specify both node['krb5']['admin_principal'] and node['krb5']['admin_password']!")
+      end
+    end
+  end
+end
+
+Chef::Recipe.send(:include, ::Krb5::Helpers)
+Chef::Resource.send(:include, ::Krb5::Helpers)
+Chef::Provider.send(:include, ::Krb5::Helpers)

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -82,6 +82,15 @@ module Krb5
       nil
     end
 
+    # Search for a principal on a KDC
+    #
+    # @result [Object, nil]
+    def kadm5_find_principal(kadm5, principal)
+      kadm5.get_principal(principal)
+    rescue PrincipalNotFoundException
+      nil
+    end
+
     private
 
     # Convert array to space-separated string

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -86,9 +86,22 @@ module Krb5
     #
     # @result [Object, nil]
     def kadm5_find_principal(kadm5, principal)
-      kadm5.get_principal(principal)
+      if principal =~ /@/
+        # Given principal includes realm
+        kadm5.get_principal(principal)
+      else
+        kadm5.get_principal("principal@#{krb5_default_realm}")
+      end
     rescue Kerberos::Kadm5::PrincipalNotFoundException
       return nil
+    end
+
+    # Get default realm
+    #
+    # @result String
+    def krb5_default_realm
+      krb5 = krb5_init
+      krb5.get_default_realm
     end
 
     # Converts principals array to a string

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -91,6 +91,13 @@ module Krb5
       nil
     end
 
+    # Converts principals array to a string
+    #
+    # @result String
+    def principal_list(array)
+      array_to_string(array)
+    end
+
     private
 
     # Convert array to space-separated string

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -78,7 +78,7 @@ module Krb5
     # @result [Object, nil]
     def keytab_find_principal(keytab, principal)
       keytab.get_entry(principal)
-    rescue Krb5::Keytab::Exception
+    rescue Kerberos::Krb5::Keytab::Exception
       return nil
     end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -87,7 +87,7 @@ module Krb5
     # @result [Object, nil]
     def kadm5_find_principal(kadm5, principal)
       kadm5.get_principal(principal)
-    rescue Kerberos::Krb5::PrincipalNotFoundException
+    rescue Kerberos::Kadm5::PrincipalNotFoundException
       nil
     end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -73,6 +73,15 @@ module Krb5
       Chef::Log.error("Missing gem 'rkerberos'. Use the 'rkerberos_gem' recipe to install it first.")
     end
 
+    # Search for a principal in a keytab
+    #
+    # @result [Object, nil]
+    def keytab_find_principal(keytab, principal)
+      keytab.get_entry(principal)
+    rescue Krb5::Keytab::Exception
+      nil
+    end
+
     private
 
     # Convert array to space-separated string

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -17,8 +17,6 @@
 # limitations under the License.
 #
 
-# require 'rkerberos'
-
 module Krb5
   # Helpers for Krb5
   module Helpers
@@ -39,8 +37,12 @@ module Krb5
     # Initialize Keytab
     #
     # @return Object
-    def keytab_init
-      Kerberos::Krb5::Keytab.new
+    def keytab_init(name = nil)
+      if name.nil?
+        Kerberos::Krb5::Keytab.new
+      else
+        Kerberos::Krb5::Keytab.new(name)
+      end
     end
 
     # Verify admin credentials are passed
@@ -69,6 +71,15 @@ module Krb5
       require 'rkerberos'
     rescue LoadError
       Chef::Log.error("Missing gem 'rkerberos'. Use the 'rkerberos_gem' recipe to install it first.")
+    end
+
+    private
+
+    # Convert array to space-separated string
+    #
+    # @result String
+    def array_to_string(array)
+      array.join(' ')
     end
   end
 end

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -63,6 +63,13 @@ module Krb5
     def krb5_kinit_password(user, password)
       Kerberos::Krb5.get_init_creds_password(user, password)
     end
+
+    # Load rkerberos gem
+    def krb5_load_gem
+      require 'rkerberos'
+    rescue LoadError
+      Chef::Log.error("Missing gem 'rkerberos'. Use the 'rkerberos_gem' recipe to install it first.")
+    end
   end
 end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -106,6 +106,11 @@ module Krb5
       array_to_string(array)
     end
 
+    # Change a principal's password
+    def kadm5_change_password(kadm5, principal, password)
+      kadm5.set_password(principal, password)
+    end
+
     private
 
     # Convert array to space-separated string

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,0 +1,37 @@
+#
+# Cookbook Name:: krb5
+# Library:: matchers
+#
+# Copyright © 2014 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Only define these if we've got ChefSpec
+if defined?(ChefSpec)
+  def create_krb5_keytab(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:krb5_keytab, :create, resource_name)
+  end
+
+  def delete_krb5_keytab(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:krb5_keytab, :delete, resource_name)
+  end
+
+  def create_krb5_principal(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:krb5_principal, :create, resource_name)
+  end
+
+  def delete_krb5_principal(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:krb5_principal, :delete, resource_name)
+  end
+end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'wolf31o2@gmail.com'
 license          'Apache 2.0'
 description      'Installs and configures Kerberos V authentication'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.4'
+version          '1.1.0'
 
 %w(redhat centos scientific amazon ubuntu debian suse).each do |os|
   supports os

--- a/providers/keytab.rb
+++ b/providers/keytab.rb
@@ -38,7 +38,7 @@ action :create do
       action :create
     end
 
-    principals.each do |princ|
+    new_resource.principals.each do |princ|
       kt = keytab_find_principal(keytab, princ)
       sv = kadm5_find_principal(kadm5, princ)
       if sv.nil?
@@ -49,7 +49,7 @@ action :create do
     end
 
     execute "create-#{new_resource.path}" do
-      command "kadmin -w #{node['krb5']['admin_password']} -q 'xst -q #{new_resource.path} #{principal_list(principals)}'"
+      command "kadmin -w #{node['krb5']['admin_password']} -q 'xst -q #{new_resource.path} #{principal_list(new_resource.principals)}'"
       not_if "test -e #{new_resource.path}"
       action :run
     end

--- a/providers/keytab.rb
+++ b/providers/keytab.rb
@@ -49,7 +49,7 @@ action :create do
     end
 
     execute "create-#{new_resource.path}" do
-      command "kadmin -w #{node['krb5']['admin_password']} -q 'xst -q #{new_resource.path} #{principal_list(new_resource.principals)}'"
+      command "kadmin -w #{node['krb5']['admin_password']} -q 'xst -kt #{new_resource.path} #{principal_list(new_resource.principals)}'"
       not_if "test -e #{new_resource.path}"
       action :run
     end

--- a/providers/keytab.rb
+++ b/providers/keytab.rb
@@ -47,9 +47,26 @@ action :create do
         Chef::Log.info("Principal #{princ} found on server but missing from keytab")
       end
     end
+
+    execute "create-#{new_resource.path}" do
+      command "kadmin -w #{node['krb5']['admin_password']} -q 'xst -q #{new_resource.path} #{principal_list(principals)}'"
+      not_if "test -e #{new_resource.path}"
+      action :run
+    end
+
+    file new_resource.path do
+      owner new_resource.owner
+      group new_resource.group
+      mode  new_resource.mode
+      action :create
+    end
   ensure
     keytab.close
   end
+end
 
-  # keytab_dir = node['krb5']['keytabs_dir']
+action :delete do
+  file new_resource.path do
+    action :delete
+  end
 end

--- a/providers/keytab.rb
+++ b/providers/keytab.rb
@@ -31,6 +31,7 @@ action :create do
     kadm5 = kadm5_init(node['krb5']['admin_principal'], node['krb5']['admin_password'])
     keytab = keytab_init("FILE:#{new_resource.path}")
 
+    # Should we use @current_resource.exists here instead?
     unless ::File.exist?(new_resource.path)
 
       directory ::File.dirname(new_resource.path) do

--- a/providers/keytab.rb
+++ b/providers/keytab.rb
@@ -42,13 +42,9 @@ action :create do
       end
 
       new_resource.principals.each do |princ|
-        # kt = keytab_find_principal(keytab, princ)
         sv = kadm5_find_principal(kadm5, princ)
-        if sv.nil?
-          Chef::Application.fatal!("Principal #{princ} not found on KDC! Perhaps, you need to create it with krb5_principal, first.")
-        # elsif kt.nil?
-        #   Chef::Log.info("Principal #{princ} found on server but missing from keytab")
-        end
+        next unless sv.nil?
+        Chef::Application.fatal!("Principal #{princ} not found on KDC! Perhaps, you need to create it with krb5_principal, first.")
       end
 
       principals = principal_list(new_resource.principals)

--- a/providers/keytab.rb
+++ b/providers/keytab.rb
@@ -19,9 +19,7 @@
 
 use_inline_resources if defined?(use_inline_resources)
 
-def whyrun_supported?
-  true
-end
+# TODO: guards for whyrun_supported?
 
 action :create do
   krb5_load_gem

--- a/providers/keytab.rb
+++ b/providers/keytab.rb
@@ -31,7 +31,7 @@ action :create do
     kadm5 = kadm5_init(node['krb5']['admin_principal'], node['krb5']['admin_password'])
     keytab = keytab_init("FILE:#{new_resource.path}")
 
-    directory File.dirname(new_resource.path) do
+    directory ::File.dirname(new_resource.path) do
       owner 'root'
       group 'root'
       mode '0755'

--- a/providers/keytab.rb
+++ b/providers/keytab.rb
@@ -31,36 +31,40 @@ action :create do
     kadm5 = kadm5_init(node['krb5']['admin_principal'], node['krb5']['admin_password'])
     keytab = keytab_init("FILE:#{new_resource.path}")
 
-    directory ::File.dirname(new_resource.path) do
-      owner 'root'
-      group 'root'
-      mode '0755'
-      action :create
-    end
+    unless ::File.exist?(new_resource.path)
 
-    new_resource.principals.each do |princ|
-      # kt = keytab_find_principal(keytab, princ)
-      sv = kadm5_find_principal(kadm5, princ)
-      if sv.nil?
-        Chef::Application.fatal!("Principal #{princ} not found on KDC! Perhaps, you need to create it with krb5_principal, first.")
-      # elsif kt.nil?
-      #   Chef::Log.info("Principal #{princ} found on server but missing from keytab")
-      else
-        Chef::Log.info("Principal #{princ} found on server")
+      directory ::File.dirname(new_resource.path) do
+        owner 'root'
+        group 'root'
+        mode '0755'
+        action :create
       end
-    end
 
-    execute "create-#{new_resource.path}" do
-      command "kadmin -w #{node['krb5']['admin_password']} -q 'xst -kt #{new_resource.path} #{principal_list(new_resource.principals)}'"
-      not_if "test -e #{new_resource.path}"
-      action :run
-    end
+      new_resource.principals.each do |princ|
+        # kt = keytab_find_principal(keytab, princ)
+        sv = kadm5_find_principal(kadm5, princ)
+        if sv.nil?
+          Chef::Application.fatal!("Principal #{princ} not found on KDC! Perhaps, you need to create it with krb5_principal, first.")
+        # elsif kt.nil?
+        #   Chef::Log.info("Principal #{princ} found on server but missing from keytab")
+        else
+          Chef::Log.info("Principal #{princ} found on server")
+        end
+      end
 
-    file new_resource.path do
-      owner new_resource.owner
-      group new_resource.group
-      mode  new_resource.mode
-      action :create
+      principals = principal_list(new_resource.principals)
+      execute "create-#{new_resource.path}" do
+        command "kadmin -w #{node['krb5']['admin_password']} -q 'xst -kt #{new_resource.path} #{principals}'"
+        not_if "test -e #{new_resource.path}"
+        action :run
+      end
+
+      file new_resource.path do
+        owner new_resource.owner
+        group new_resource.group
+        mode  new_resource.mode
+        action :create
+      end
     end
   ensure
     keytab.close
@@ -68,7 +72,10 @@ action :create do
 end
 
 action :delete do
-  file new_resource.path do
-    action :delete
+  if ::File.exist?(new_resource.path)
+    Chef::Log.info("Removing #{new_resource.name} keytab file")
+    file new_resource.path do
+      action :delete
+    end
   end
 end

--- a/providers/keytab.rb
+++ b/providers/keytab.rb
@@ -47,13 +47,11 @@ action :create do
           Chef::Application.fatal!("Principal #{princ} not found on KDC! Perhaps, you need to create it with krb5_principal, first.")
         # elsif kt.nil?
         #   Chef::Log.info("Principal #{princ} found on server but missing from keytab")
-        else
-          Chef::Log.info("Principal #{princ} found on server")
         end
       end
 
       principals = principal_list(new_resource.principals)
-      execute "create-#{new_resource.path}" do
+      execute "create #{new_resource.path}" do
         command "kadmin -w #{node['krb5']['admin_password']} -q 'xst -kt #{new_resource.path} #{principals}'"
         not_if "test -e #{new_resource.path}"
         action :run

--- a/providers/keytab.rb
+++ b/providers/keytab.rb
@@ -31,7 +31,7 @@ action :create do
     kadm5 = kadm5_init(node['krb5']['admin_principal'], node['krb5']['admin_password'])
     keytab = keytab_init("FILE:#{new_resource.path}")
 
-    directory File::Dirname(new_resource.path) do
+    directory File.dirname(new_resource.path) do
       owner 'root'
       group 'root'
       mode '0755'

--- a/providers/keytab.rb
+++ b/providers/keytab.rb
@@ -39,12 +39,14 @@ action :create do
     end
 
     new_resource.principals.each do |princ|
-      kt = keytab_find_principal(keytab, princ)
+      # kt = keytab_find_principal(keytab, princ)
       sv = kadm5_find_principal(kadm5, princ)
       if sv.nil?
         Chef::Application.fatal!("Principal #{princ} not found on KDC! Perhaps, you need to create it with krb5_principal, first.")
-      elsif kt.nil?
-        Chef::Log.info("Principal #{princ} found on server but missing from keytab")
+      # elsif kt.nil?
+      #   Chef::Log.info("Principal #{princ} found on server but missing from keytab")
+      else
+        Chef::Log.info("Principal #{princ} found on server")
       end
     end
 

--- a/providers/keytab.rb
+++ b/providers/keytab.rb
@@ -42,7 +42,7 @@ action :create do
       new_resource.principals.each do |princ|
         sv = kadm5_find_principal(kadm5, princ)
         next unless sv.nil?
-        Chef::Application.fatal!("Principal #{princ} not found on KDC! Perhaps, you need to create it with krb5_principal, first.")
+        Chef::Application.fatal!("Principal #{princ} not found on KDC! Perhaps you need to create it with krb5_principal, first.")
       end
 
       principals = principal_list(new_resource.principals)

--- a/providers/keytab.rb
+++ b/providers/keytab.rb
@@ -26,7 +26,7 @@ end
 action :create do
   krb5_load_gem
   krb5_verify_admin
-  Chef::Application.fatal!('You myst specify at least one principal') unless new_resource.principals.empty?
+  Chef::Application.fatal!('You myst specify at least one principal') if new_resource.principals.empty?
   begin
     kadm5 = kadm5_init(node['krb5']['admin_principal'], node['krb5']['admin_password'])
     keytab = keytab_init("FILE:#{new_resource.path}")

--- a/providers/keytab.rb
+++ b/providers/keytab.rb
@@ -1,0 +1,55 @@
+#
+# Cookbook Name:: krb5
+# Provider:: keytab
+#
+# Copyright © 2014 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+use_inline_resources if defined?(use_inline_resources)
+
+def whyrun_supported?
+  true
+end
+
+action :create do
+  krb5_load_gem
+  krb5_verify_admin
+  Chef::Application.fatal!('You myst specify at least one principal') unless new_resource.principals.empty?
+  begin
+    kadm5 = kadm5_init(node['krb5']['admin_principal'], node['krb5']['admin_password'])
+    keytab = keytab_init("FILE:#{new_resource.path}")
+
+    directory File::Dirname(new_resource.path) do
+      owner 'root'
+      group 'root'
+      mode '0755'
+      action :create
+    end
+
+    principals.each do |princ|
+      kt = keytab_find_principal(keytab, princ)
+      sv = kadm5_find_principal(kadm5, princ)
+      if sv.nil?
+        Chef::Application.fatal!("Principal #{princ} not found on KDC! Perhaps, you need to create it with krb5_principal, first.")
+      elsif kt.nil?
+        Chef::Log.info("Principal #{princ} found on server but missing from keytab")
+      end
+    end
+  ensure
+    keytab.close
+  end
+
+  # keytab_dir = node['krb5']['keytabs_dir']
+end

--- a/providers/keytab.rb
+++ b/providers/keytab.rb
@@ -18,13 +18,13 @@
 #
 
 use_inline_resources if defined?(use_inline_resources)
-
+include Krb5::Helpers
 # TODO: guards for whyrun_supported?
 
 action :create do
   krb5_load_gem
   krb5_verify_admin
-  Chef::Application.fatal!('You myst specify at least one principal') if new_resource.principals.empty?
+  Chef::Application.fatal!('You must specify at least one principal') if new_resource.principals.empty?
   begin
     kadm5 = kadm5_init(node['krb5']['admin_principal'], node['krb5']['admin_password'])
     keytab = keytab_init("FILE:#{new_resource.path}")

--- a/providers/keytab.rb
+++ b/providers/keytab.rb
@@ -24,7 +24,6 @@ include Krb5::Helpers
 action :create do
   krb5_load_gem
   krb5_verify_admin
-  Chef::Application.fatal!('You must specify at least one principal') if new_resource.principals.empty?
   begin
     kadm5 = kadm5_init(node['krb5']['admin_principal'], node['krb5']['admin_password'])
     keytab = keytab_init("FILE:#{new_resource.path}")

--- a/providers/principal.rb
+++ b/providers/principal.rb
@@ -34,6 +34,11 @@ action :create do
              new_resource.password
            end
   begin
+    if new_resource.randkey
+      Chef::Log.info("Creating #{new_resource.name} principal with random key")
+    else
+      Chef::Log.info("Creating #{new_resource.name} principal with user-provided password")
+    end
     kadm5.create_principal(new_resource.principal, mypass)
     kadm5.generate_random_key(new_resource.principal) if new_resource.randkey
   ensure
@@ -45,6 +50,7 @@ action :delete do
   krb5_verify_admin
   kadm5 = kadm5_init(node['krb5']['admin_principal'], node['krb5']['admin_password'])
   begin
+    Chef::Log.info("Removing #{new_resource.name} principal from Kerberos")
     kadm5.delete_principal(new_resource.principal)
   ensure
     kadm5.close

--- a/providers/principal.rb
+++ b/providers/principal.rb
@@ -27,6 +27,7 @@ action :create do
   krb5_load_gem
   krb5_verify_admin
   kadm5 = kadm5_init(node['krb5']['admin_principal'], node['krb5']['admin_password'])
+  return unless kadm5_find_principal(kadm5, new_resource.name).nil?
   mypass = if new_resource.password.nil?
              'placeholder12345'
            else
@@ -49,6 +50,7 @@ action :delete do
   krb5_load_gem
   krb5_verify_admin
   kadm5 = kadm5_init(node['krb5']['admin_principal'], node['krb5']['admin_password'])
+  return if kadm5_find_principal(kadm5, new_resource.name).nil?
   begin
     Chef::Log.info("Removing #{new_resource.name} principal from Kerberos")
     kadm5.delete_principal(new_resource.principal)

--- a/providers/principal.rb
+++ b/providers/principal.rb
@@ -43,6 +43,7 @@ action :create do
       end
       kadm5.create_principal(new_resource.name, mypass)
       kadm5.generate_random_key(new_resource.name) if randkey
+      new_resource.updated_by_last_action(true)
     end
   ensure
     kadm5.close
@@ -57,6 +58,7 @@ action :delete do
     unless kadm5_find_principal(kadm5, new_resource.name).nil?
       Chef::Log.info("Removing #{new_resource.name} principal from Kerberos")
       kadm5.delete_principal(new_resource.name)
+      new_resource.updated_by_last_action(true)
     end
   ensure
     kadm5.close

--- a/providers/principal.rb
+++ b/providers/principal.rb
@@ -27,7 +27,6 @@ action :create do
   krb5_load_gem
   krb5_verify_admin
   begin
-
     kadm5 = kadm5_init(node['krb5']['admin_principal'], node['krb5']['admin_password'])
     randkey = new_resource.randkey
     mypass = if new_resource.password.nil?
@@ -36,7 +35,6 @@ action :create do
                new_resource.password
                randkey = false
              end
-
     if kadm5_find_principal(kadm5, new_resource.name).nil?
       if randkey
         Chef::Log.info("Creating #{new_resource.name} principal with random key")

--- a/providers/principal.rb
+++ b/providers/principal.rb
@@ -35,11 +35,11 @@ action :create do
                new_resource.password
                randkey = false
              end
-    if kadm5_find_principal(kadm5, new_resource.name).nil?
+    if kadm5_find_principal(kadm5, new_resource.principal).nil?
       if randkey
-        Chef::Log.info("Creating #{new_resource.name} principal with random key")
+        Chef::Log.info("Creating #{new_resource.principal} principal with random key")
       else
-        Chef::Log.info("Creating #{new_resource.name} principal with user-provided password")
+        Chef::Log.info("Creating #{new_resource.principal} principal with user-provided password")
       end
       kadm5.create_principal(new_resource.principal, mypass)
       kadm5.generate_random_key(new_resource.principal) if randkey
@@ -54,8 +54,8 @@ action :delete do
   krb5_verify_admin
   begin
     kadm5 = kadm5_init(node['krb5']['admin_principal'], node['krb5']['admin_password'])
-    unless kadm5_find_principal(kadm5, new_resource.name).nil?
-      Chef::Log.info("Removing #{new_resource.name} principal from Kerberos")
+    unless kadm5_find_principal(kadm5, new_resource.principal).nil?
+      Chef::Log.info("Removing #{new_resource.principal} principal from Kerberos")
       kadm5.delete_principal(new_resource.principal)
     end
   ensure

--- a/providers/principal.rb
+++ b/providers/principal.rb
@@ -34,11 +34,7 @@ action :create do
       randkey = false
     end
     if kadm5_find_principal(kadm5, new_resource.name).nil?
-      if randkey
-        Chef::Log.info("Creating #{new_resource.name} principal with random key")
-      else
-        Chef::Log.info("Creating #{new_resource.name} principal with user-provided password")
-      end
+      Chef::Log.info("Creating #{new_resource.name} principal with #{randkey ? 'random key' : 'user-provided password'}")
       kadm5.create_principal(new_resource.name, mypass)
       kadm5.generate_random_key(new_resource.name) if randkey
       new_resource.updated_by_last_action(true)

--- a/providers/principal.rb
+++ b/providers/principal.rb
@@ -28,7 +28,11 @@ end
 action :create do
   krb5_verify_admin
   kadm5 = kadm5_init(node['krb5']['admin_principal'], node['krb5']['admin_password'])
-  mypass = 'placeholder12345' if new_resource.password.nil?
+  mypass = if new_resource.password.nil?
+             'placeholder12345'
+           else
+             new_resource.password
+           end
   begin
     kadm5.create_principal(new_resource.principal, mypass)
     kadm5.generate_random_key(new_resource.principal) if new_resource.randkey

--- a/providers/principal.rb
+++ b/providers/principal.rb
@@ -1,0 +1,48 @@
+#
+# Cookbook Name:: krb5
+# Provider:: principal
+#
+# Copyright © 2014 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# require 'rkerberos'
+
+use_inline_resources if defined?(use_inline_resources)
+
+def whyrun_supported?
+  true
+end
+
+action :create do
+  krb5_verify_admin
+  kadm5 = kadm5_init(node['krb5']['admin_principal'], node['krb5']['admin_password'])
+  mypass = 'placeholder12345' if new_resource.password.nil?
+  begin
+    kadm5.create_principal(new_resource.principal, mypass)
+    kadm5.generate_random_key(new_resource.principal) if new_resource.randkey
+  ensure
+    kadm5.close
+  end
+end
+
+action :delete do
+  krb5_verify_admin
+  kadm5 = kadm5_init(node['krb5']['admin_principal'], node['krb5']['admin_password'])
+  begin
+    kadm5.delete_principal(new_resource.principal)
+  ensure
+    kadm5.close
+  end
+end

--- a/providers/principal.rb
+++ b/providers/principal.rb
@@ -17,8 +17,6 @@
 # limitations under the License.
 #
 
-# require 'rkerberos'
-
 use_inline_resources if defined?(use_inline_resources)
 
 def whyrun_supported?
@@ -26,6 +24,7 @@ def whyrun_supported?
 end
 
 action :create do
+  krb5_load_gem
   krb5_verify_admin
   kadm5 = kadm5_init(node['krb5']['admin_principal'], node['krb5']['admin_password'])
   mypass = if new_resource.password.nil?
@@ -47,6 +46,7 @@ action :create do
 end
 
 action :delete do
+  krb5_load_gem
   krb5_verify_admin
   kadm5 = kadm5_init(node['krb5']['admin_principal'], node['krb5']['admin_password'])
   begin

--- a/providers/principal.rb
+++ b/providers/principal.rb
@@ -18,10 +18,8 @@
 #
 
 use_inline_resources if defined?(use_inline_resources)
-
-def whyrun_supported?
-  true
-end
+include Krb5::Helpers
+# TODO: guards for whyrun_supported?
 
 action :create do
   krb5_load_gem

--- a/providers/principal.rb
+++ b/providers/principal.rb
@@ -35,14 +35,14 @@ action :create do
                new_resource.password
                randkey = false
              end
-    if kadm5_find_principal(kadm5, new_resource.principal).nil?
+    if kadm5_find_principal(kadm5, new_resource.name).nil?
       if randkey
-        Chef::Log.info("Creating #{new_resource.principal} principal with random key")
+        Chef::Log.info("Creating #{new_resource.name} principal with random key")
       else
-        Chef::Log.info("Creating #{new_resource.principal} principal with user-provided password")
+        Chef::Log.info("Creating #{new_resource.name} principal with user-provided password")
       end
-      kadm5.create_principal(new_resource.principal, mypass)
-      kadm5.generate_random_key(new_resource.principal) if randkey
+      kadm5.create_principal(new_resource.name, mypass)
+      kadm5.generate_random_key(new_resource.name) if randkey
     end
   ensure
     kadm5.close
@@ -54,9 +54,9 @@ action :delete do
   krb5_verify_admin
   begin
     kadm5 = kadm5_init(node['krb5']['admin_principal'], node['krb5']['admin_password'])
-    unless kadm5_find_principal(kadm5, new_resource.principal).nil?
-      Chef::Log.info("Removing #{new_resource.principal} principal from Kerberos")
-      kadm5.delete_principal(new_resource.principal)
+    unless kadm5_find_principal(kadm5, new_resource.name).nil?
+      Chef::Log.info("Removing #{new_resource.name} principal from Kerberos")
+      kadm5.delete_principal(new_resource.name)
     end
   ensure
     kadm5.close

--- a/providers/principal.rb
+++ b/providers/principal.rb
@@ -29,12 +29,12 @@ action :create do
   begin
     kadm5 = kadm5_init(node['krb5']['admin_principal'], node['krb5']['admin_password'])
     randkey = new_resource.randkey
-    mypass = if new_resource.password.nil?
-               'placeholder12345'
-             else
-               new_resource.password
-               randkey = false
-             end
+    if new_resource.password.nil?
+      mypass = 'placeholder12345'
+    else
+      mypass = new_resource.password
+      randkey = false
+    end
     if kadm5_find_principal(kadm5, new_resource.name).nil?
       if randkey
         Chef::Log.info("Creating #{new_resource.name} principal with random key")

--- a/recipes/rkerberos_gem.rb
+++ b/recipes/rkerberos_gem.rb
@@ -27,4 +27,4 @@ chef_gem 'rkerberos' do
   action :install
 end
 
-require 'rkerberos'
+require 'rkerberos' unless defined?(ChefSpec)

--- a/recipes/rkerberos_gem.rb
+++ b/recipes/rkerberos_gem.rb
@@ -1,0 +1,24 @@
+#
+# Cookbook Name:: krb5
+# Recipe:: rkerberos_gem
+#
+# Copyright © 2014 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+chef_gem 'rkerberos' do
+  action :install
+end
+
+require 'rkerberos'

--- a/recipes/rkerberos_gem.rb
+++ b/recipes/rkerberos_gem.rb
@@ -17,6 +17,12 @@
 # limitations under the License.
 #
 
+node['krb5']['devel']['packages'].each do |pkg|
+  package pkg do
+    action :install
+  end
+end
+
 chef_gem 'rkerberos' do
   action :install
 end

--- a/recipes/rkerberos_gem.rb
+++ b/recipes/rkerberos_gem.rb
@@ -19,8 +19,8 @@
 
 node['krb5']['devel']['packages'].each do |pkg|
   package pkg do
-    action :install
-  end
+    action :nothing
+  end.run_action(:install)
 end
 
 chef_gem 'rkerberos' do

--- a/resources/keytab.rb
+++ b/resources/keytab.rb
@@ -24,4 +24,4 @@ attribute :path,       :kind_of => String,         :default => nil,    :name_att
 attribute :principals, :kind_of => Array,          :default => []
 attribute :owner,      :kind_of => String,         :default => 'root'
 attribute :group,      :kind_of => String,         :default => 'root'
-attribute :mode,       :kind_of => String,         :default => '0640'
+attribute :mode,       :kind_of => String,         :default => '0600'

--- a/resources/keytab.rb
+++ b/resources/keytab.rb
@@ -1,0 +1,27 @@
+#
+# Cookbook Name:: krb5
+# Resource:: keytab
+#
+# Copyright © 2014 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+actions :create, :delete
+default_action :create
+
+attribute :path,       :kind_of => String,         :default => nil,    :name_attribute => true
+attribute :principals, :kind_of => Array,          :default => []
+attribute :owner,      :kind_of => String,         :default => 'root'
+attribute :group,      :kind_of => String,         :default => 'root'
+attribute :mode,       :kind_of => String,         :default => '0640'

--- a/resources/keytab.rb
+++ b/resources/keytab.rb
@@ -21,7 +21,7 @@ actions :create, :delete
 default_action :create
 
 attribute :path,       :kind_of => String,         :default => nil,    :name_attribute => true
-attribute :principals, :kind_of => Array,          :default => []
+attribute :principals, :kind_of => Array,          :default => [],     :required => true
 attribute :owner,      :kind_of => String,         :default => 'root'
 attribute :group,      :kind_of => String,         :default => 'root'
 attribute :mode,       :kind_of => String,         :default => '0600'

--- a/resources/principal.rb
+++ b/resources/principal.rb
@@ -1,0 +1,25 @@
+#
+# Cookbook Name:: krb5
+# Resource:: principal
+#
+# Copyright © 2014 Cask Data, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+actions :create, :delete
+default_action :create
+
+attribute :principal, :kind_of => String,         :default => nil, :name_attribute => true
+attribute :randkey,   :equal_to => [true, false], :default => true
+attribute :password,  :kind_of => String,         :default => nil

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -31,7 +31,6 @@ describe 'krb5::default' do
     it 'executes execute[krb5-authconfig] block' do
       expect(chef_run).not_to run_execute('krb5-authconfig')
     end
-
   end
 
   context 'on Ubuntu 13.04' do

--- a/spec/kadmin_spec.rb
+++ b/spec/kadmin_spec.rb
@@ -25,7 +25,6 @@ describe 'krb5::kadmin' do
         /\*\/admin@EXAMPLE.COM\t\*/
       )
     end
-
   end
 
   context 'on Ubuntu 13.04' do

--- a/spec/kdc_spec.rb
+++ b/spec/kdc_spec.rb
@@ -41,6 +41,5 @@ describe 'krb5::kdc' do
     it 'creates kdc.conf template' do
       expect(chef_run).to create_template('/var/lib/krb5kdc/kdc.conf')
     end
-
   end
 end

--- a/spec/rkerberos_gem_spec.rb
+++ b/spec/rkerberos_gem_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe 'krb5::rkerberos_gem' do
+  context 'on Centos 6.5 x86_64' do
+    let(:chef_run) do
+      ChefSpec::Runner.new(platform: 'centos', version: 6.5) do |node|
+        node.automatic['domain'] = 'example.com'
+      end.converge(described_recipe)
+    end
+
+    it 'installs rkerberos chef_gem' do
+      expect(chef_run).to install_chef_gem('rkerberos')
+    end
+
+    it 'installs krb5-devel package' do
+      expect(chef_run).to install_package('krb5-devel')
+    end
+
+  end
+
+  context 'on Ubuntu 13.04' do
+    let(:chef_run) do
+      ChefSpec::Runner.new(platform: 'ubuntu', version: 13.04) do |node|
+        node.automatic['domain'] = 'example.com'
+      end.converge(described_recipe)
+    end
+
+    it 'installs libkrb5-dev package' do
+      expect(chef_run).to install_package('libkrb5-dev')
+    end
+  end
+end

--- a/spec/rkerberos_gem_spec.rb
+++ b/spec/rkerberos_gem_spec.rb
@@ -15,7 +15,6 @@ describe 'krb5::rkerberos_gem' do
     it 'installs krb5-devel package' do
       expect(chef_run).to install_package('krb5-devel')
     end
-
   end
 
   context 'on Ubuntu 13.04' do

--- a/spec/rkerberos_gem_spec.rb
+++ b/spec/rkerberos_gem_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'krb5::rkerberos_gem' do
   context 'on Centos 6.5 x86_64' do
     let(:chef_run) do
-      ChefSpec::Runner.new(platform: 'centos', version: 6.5) do |node|
+      ChefSpec::SoloRunner.new(platform: 'centos', version: 6.5) do |node|
         node.automatic['domain'] = 'example.com'
       end.converge(described_recipe)
     end
@@ -19,7 +19,7 @@ describe 'krb5::rkerberos_gem' do
 
   context 'on Ubuntu 13.04' do
     let(:chef_run) do
-      ChefSpec::Runner.new(platform: 'ubuntu', version: 13.04) do |node|
+      ChefSpec::SoloRunner.new(platform: 'ubuntu', version: 13.04) do |node|
         node.automatic['domain'] = 'example.com'
       end.converge(described_recipe)
     end


### PR DESCRIPTION
This allows for the creation/deletion of principals (in the default realm, only) via a Kerberos Admin server using the `rkerberos` Ruby gem. It also supports the creation of keytab files, using Kerberos administrator credentials. Currently, there is no support for adding/removing entries from the keytab file, which is a limitation of `rkerberos` gem. The LWRP will not stomp on an existing keytab file. This will likely require a couple iterations before it's perfect, but it seems to work for me for my use case (setting up Kerberos for Hadoop clusters).