### PR TITLE
Changes for GMTI compatibility.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ This cookbook has changed the attribute format, but is backwards compatible with
 
  * `krb5['krb5_conf']['realms']['default_realm']` - The default realm, defaults to `krb5['krb5_conf']['libdefaults']['default_realm']`
  * `krb5['krb5_conf']['realms']['default_realm_kdcs']` - Array of Kerberos servers for default realm.  Default is empty.
+ * `krb5['krb5_conf']['realms']['default_realm_kdcs_dns']` - Boolean, (true | false) use DNS as opposed to specifying kdc. Will not write kdc= if true, will use DNS.
+ * `krb5['krb5_conf']['realms']['default_realm_kdcs_default_domain']` - If set writed default domain - primarily for krb4 compatibility..
  * `krb5['krb5_conf']['realms']['default_realm_admin_server']` - Address of Kerberos admin server.  Defaults to empty.
  * `krb5['krb5_conf']['realms']['realms']` - Array of all realms, including the default.  Defaults to OHAI's domain attribute.
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -65,7 +65,7 @@ default['krb5']['forwardable'] = 'true'
 
 default_realm =
   if node['krb5'].key?('krb5_conf') && node['krb5']['krb5_conf'].key?('libdefaults') &&
-     node['krb5']['krb5_conf']['libdefaults'].key?('default_realm')
+    node['krb5']['krb5_conf']['libdefaults'].key?('default_realm')
     node['krb5']['krb5_conf']['libdefaults']['default_realm'].upcase
   elsif node['krb5']['default_realm']
     node['krb5']['default_realm'].upcase
@@ -96,6 +96,8 @@ default['krb5']['krb5_conf']['libdefaults']['ticket_lifetime'] = node['krb5']['t
 # realms
 default['krb5']['krb5_conf']['realms']['default_realm'] = node['krb5']['krb5_conf']['libdefaults']['default_realm']
 default['krb5']['krb5_conf']['realms']['default_realm_kdcs'] = node['krb5']['default_realm_kdcs']
+default['krb5']['krb5_conf']['realms']['default_realm_kdcs_dns'] = false
+default['krb5']['krb5_conf']['realms']['default_realm_kdcs_default_domain'] = '' 
 default['krb5']['krb5_conf']['realms']['default_realm_admin_server'] = ''
 default['krb5']['krb5_conf']['realms']['realms'] = node['krb5']['realms']
 

--- a/templates/default/krb5.conf.erb
+++ b/templates/default/krb5.conf.erb
@@ -20,16 +20,21 @@
 <% if @realms %>
 [realms]
  <% unless node['krb5']['krb5_conf']['realms']['default_realm_kdcs'].empty? -%>
- <%= node['krb5']['krb5_conf']['realms']['default_realm'].upcase %> = {
-  <% node['krb5']['krb5_conf']['realms']['default_realm_kdcs'].each do |kdc_server| -%>
-  kdc = <%= kdc_server %>
+    <%= node['krb5']['krb5_conf']['realms']['default_realm'].upcase %> = {
+    <% node['krb5']['krb5_conf']['realms']['default_realm_kdcs'].each do |kdc_server| -%>
+    <% if !node['krb5']['krb5_conf']['realms']['default_realm_kdcs_dns'] -%>
+        kdc = <%= kdc_server %>
+    <% end -%>
+    <% if node['krb5']['krb5_conf']['realms']['default_realm_kdcs_default_domain'] -%>
+        default_domain = <%= node['krb5']['krb5_conf']['realms']['default_realm_kdcs_default_domain'] %>
+    <% end -%>
   <% end -%>
   <% unless node['krb5']['krb5_conf']['realms']['default_realm_admin_server'].empty? -%>
-  admin_server = <%=  node['krb5']['krb5_conf']['realms']['default_realm_admin_server'] %>
+  admin_server = <%= node['krb5']['krb5_conf']['realms']['default_realm_admin_server'] %>
   <% end %>
  }
  <% end -%>
-
+[domain_realm]
  <% node['krb5']['krb5_conf']['realms']['realms'].each do |krb5_realm| -%>
  <%= krb5_realm.downcase -%> = <%= krb5_realm.upcase %>
  .<%= krb5_realm.downcase -%> = <%= krb5_realm.upcase %>


### PR DESCRIPTION
adding capability to turn of kdc and use dns for host running kdc for realm and the ability to set the default domain for krb4 backwards compatibility.