### PR TITLE
Authconfig Execute w/ Test

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,12 +1,13 @@
 ---
 driver:
-  name: vagrant 
+  name: vagrant
 
 provisioner:
-  name: chef_solo
+  name: chef_zero
 
 platforms:
-- name: centos-6.5
+- name: centos-6.6
+- name: centos-7.1
 
 suites:
 - name: default

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -3,7 +3,7 @@ driver:
   name: vagrant
 
 provisioner:
-  name: chef_zero
+  name: chef_solo
 
 platforms:
 - name: centos-6.6

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -25,7 +25,6 @@ end
 
 execute 'krb5-authconfig' do
   command node['krb5']['client']['authconfig']
-  not_if { 'grep pam_krb5 /etc/pam.d/system-auth' || 'grep pam_krb5 /etc/pam.d/common-auth' }
   action :nothing
 end
 

--- a/test/integration/default/serverspec/pam_krb5_spec.rb
+++ b/test/integration/default/serverspec/pam_krb5_spec.rb
@@ -3,9 +3,7 @@ require 'serverspec'
 set :backend, :exec
 
 describe 'PAM KRB5 Authentication' do
-
   describe command('authconfig --test') do
-    its(:stdout) { should match /pam_krb5 is enabled/ }
+    its(:stdout) { should match(/pam_krb5 is enabled/) }
   end
-
 end

--- a/test/integration/default/serverspec/pam_krb5_spec.rb
+++ b/test/integration/default/serverspec/pam_krb5_spec.rb
@@ -1,0 +1,11 @@
+require 'serverspec'
+
+set :backend, :exec
+
+describe 'PAM KRB5 Authentication' do
+
+  describe command('authconfig --test') do
+    its(:stdout) { should match /pam_krb5 is enabled/ }
+  end
+
+end


### PR DESCRIPTION
This removes a `not_if` guard around the authconfig execute block. Included is a test to query authconfig and determine if `pam_krb5` is enabled. This test fails on a 'clean' system with the guard and passes when the guard is removed.