### PR TITLE
Install build-essential at compile time

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,3 +19,6 @@ suites:
   - recipe[krb5::kadmin_service]
   - recipe[krb5::kdc_service]
   attributes: { krb5: { kadmin: { service_actions: 'start' }, kdc: { service_actions: 'start' } }, krb5_conf: { realms: { default_realm_admin_server: 'localhost' } } }
+- name: rkerberos
+  run_list:
+  - recipe[krb5::rkerberos_gem]

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Author:: Chris Gianelloni
 
 Copyright:: © 2012-2014 Eric G. Wolfe
 
-Copyright:: © 2014 Cask Data, Inc.
+Copyright:: © 2014-2015 Cask Data, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -65,6 +65,9 @@ default_realm =
 # Default location for keytabs generated from LWRP
 default['krb5']['keytabs_dir'] = '/etc/security/keytabs'
 
+# Install build-essential at compile time
+override['build-essential']['compile_time'] = true
+
 # Client Packages
 default['krb5']['client']['packages'] = node['krb5']['packages']
 default['krb5']['client']['authconfig'] = node['krb5']['authconfig']

--- a/metadata.rb
+++ b/metadata.rb
@@ -10,4 +10,5 @@ version          '2.0.0'
   supports os
 end
 
+depends 'build-essential'
 depends 'ntp'

--- a/recipes/rkerberos_gem.rb
+++ b/recipes/rkerberos_gem.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: krb5
 # Recipe:: rkerberos_gem
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2015 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+include_recipe 'build-essential'
 
 node['krb5']['devel']['packages'].each do |pkg|
   package pkg do


### PR DESCRIPTION
Otherwise, the Gem will fail to build due to missing dependencies.