### PR TITLE
Update Gem/cookbook restrictions and rubocop configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ LineLength:
   Max: 200
 HashSyntax:
   Enabled: False
-SingleSpaceBeforeFirstArg:
+SpaceBeforeFirstArg:
   Enabled: false
 AsciiComments:
   Enabled: false

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,10 @@
-source 'https://api.berkshelf.com'
+source 'https://supermarket.chef.io'
+
+# Restrict version due to Chef 12 requirement
+if RUBY_VERSION.to_f < 2.0
+  cookbook 'apt', '< 4.0'
+  cookbook 'build-essential', '< 3.0'
+  cookbook 'ohai', '< 4.0'
+end
 
 metadata

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,24 @@ gem 'chefspec', '~> 4.0'
 gem 'rspec', '~> 3.0'
 gem 'chef-zero', '~> 2.0'
 gem 'foodcritic', '~> 3.0'
-gem 'rubocop', '~> 0.21'
+
+gem 'ridley', '~> 4.2.0'
+gem 'faraday', '< 0.9.2'
+
+gem 'rack', '< 2.0' if RUBY_VERSION.to_f < 2.2
+
+if RUBY_VERSION.to_f < 2.1
+  gem 'buff-ignore', '< 1.2'
+  gem 'fauxhai', '< 3.5'
+  gem 'dep_selector', '< 1.0.4'
+end
+
+if RUBY_VERSION.to_f < 2.0
+  gem 'chef', '< 12.0'
+  gem 'json', '< 2.0'
+  gem 'varia_model', '< 0.5.0'
+  gem 'rubocop', '< 0.42'
+end
 
 group :integration do
   gem 'test-kitchen'


### PR DESCRIPTION
This simply updates all of the Gemfile/Berksfile settings to allow the Travis tests to run with upstream changes to cookbooks and Rubygems.