### PR TITLE
Until rkerberos supports writing keytabs, kinit first

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,19 @@
+---
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - ruby
+        #mass_threshold: 20
+  fixme:
+    enabled: true
+  foodcritic:
+    enabled: true
+  rubocop:
+    enabled: true
+ratings:
+  paths:
+  - "**.rb"
+exclude_paths:
+- spec/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 #
-# Copyright © 2014 Cask Data, Inc.
+# Copyright © 2014-2016 Cask Data, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License"); you may not
 # use this file except in compliance with the License. You may obtain a copy of
@@ -17,6 +17,8 @@
 language: ruby
 rvm:
   - 1.9.3
+  - 2.0.0
+  - 2.1.4
 cache: bundler
 sudo: false
 bundler_args: --jobs 7 --without docs integration

--- a/Gemfile
+++ b/Gemfile
@@ -1,28 +1,36 @@
 source 'https://rubygems.org'
 
-gem 'berkshelf', '~> 3.1'
+gem 'berkshelf', '~> 3.0'
+
 gem 'chefspec', '~> 4.0'
 gem 'rspec', '~> 3.0'
-gem 'chef-zero', '~> 2.0'
-gem 'foodcritic', '~> 3.0'
-
-gem 'ridley', '~> 4.2.0'
-gem 'faraday', '< 0.9.2'
-
-gem 'rack', '< 2.0' if RUBY_VERSION.to_f < 2.2
 
 if RUBY_VERSION.to_f < 2.1
   gem 'buff-ignore', '< 1.2'
+  gem 'chef-zero', '< 4.6'
   gem 'fauxhai', '< 3.5'
+  gem 'ffi-yajl', '< 2.3'
   gem 'dep_selector', '< 1.0.4'
+  gem 'net-http-persistent', '< 3.0'
 end
 
 if RUBY_VERSION.to_f < 2.0
   gem 'chef', '< 12.0'
   gem 'json', '< 2.0'
-  gem 'varia_model', '< 0.5.0'
   gem 'rubocop', '< 0.42'
+  gem 'varia_model', '< 0.5.0'
+  gem 'foodcritic', '~> 4.0'
+else
+  gem 'chef', '< 12.5'
+  gem 'foodcritic', '~> 6.0'
+  gem 'rubocop'
 end
+
+gem 'rack', '< 2.0' if RUBY_VERSION.to_f < 2.2
+gem 'ridley', '~> 4.2.0'
+gem 'faraday', '< 0.9.2'
+gem 'rainbow', '<= 1.99.1'
+gem 'dep-selector-libgecode', '< 1.3.1'
 
 group :integration do
   gem 'test-kitchen'

--- a/Rakefile
+++ b/Rakefile
@@ -16,14 +16,6 @@ task :rubocop do
   sh 'rubocop --fail-level E'
 end
 
-# test-kitchen task
-begin
-  require 'kitchen/rake_tasks'
-  Kitchen::RakeTasks.new
-rescue LoadError
-  puts '>>>>> Kitchen gem not loaded, omitting tasks' unless ENV['CI']
-end
-
 # Deploy task
 desc 'Deploy to chef server and pin to environment'
 task :deploy do


### PR DESCRIPTION
Since rkerberos doesn't support writing to keytabs, we shell out to run `kinit` before running `kadmin` since the shell doesn't inherit the Ruby Kerberos credentials.

Adding a codeclimate configuration, updating Gemfile for gem restrictions, adding Ruby 2.0 and 2.1 to Travis testing, and dropping Kitchen task from Rakefile due to errors when Kitchen fails after loading, like when Vagrant is missing.