### PR TITLE
Restore rescue needed for library to function

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -78,6 +78,8 @@ module Krb5
     # @result [Object, nil]
     def keytab_find_principal(keytab, principal)
       keytab.get_entry(principal)
+    rescue Kerberos::Krb5::Keytab::Exception
+      nil
     end
 
     # Search for a principal on a KDC
@@ -85,6 +87,8 @@ module Krb5
     # @result [Object, nil]
     def kadm5_find_principal(kadm5, principal)
       kadm5.get_principal(principal)
+    rescue Kerberos::Kadm5::PrincipalNotFoundException
+      nil
     end
 
     # Get default realm


### PR DESCRIPTION
Restore the rescue blocks necessary for a failed lookup to not cause
the Chef run to abort.

Fixes:
```
    ================================================================================
    Error executing action `create` on resource 'krb5_principal[host/dokken.mesos]'
    ================================================================================

    Kerberos::Kadm5::PrincipalNotFoundException
    -------------------------------------------
    principal not found
```

Signed-off-by: Chris Gianelloni <wolf31o2@gmail.com>