### PR TITLE
Update how we default kadmind and KDC services

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -28,7 +28,15 @@ suites:
     - recipe[krb5::kadmin_init]
     - recipe[krb5::kadmin_service]
     - recipe[krb5::kdc_service]
-    attributes: { krb5: { kadmin: { service_actions: 'start' }, kdc: { service_actions: 'start' } }, krb5_conf: { realms: { default_realm_admin_server: 'localhost' } } }
+    attributes:
+      krb5:
+        kadmin:
+          service_actions: 'start'
+        kdc:
+          service_actions: 'start'
+        krb5_conf:
+          realms:
+            default_realm_admin_server: 'localhost'
   - name: rkerberos
     run_list:
     - recipe[krb5::rkerberos_gem]

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ before_script:
   - chef --version
   - cookstyle --version
   - foodcritic --version
-  - gem install zookeeper
 
 script: KITCHEN_LOCAL_YAML=.kitchen.dokken.yml kitchen verify ${INSTANCE}
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -92,8 +92,8 @@ default['krb5']['krb5_conf']['libdefaults']['ticket_lifetime'] = '24h'
 
 # realms
 default['krb5']['krb5_conf']['realms']['default_realm'] = default_realm
-default['krb5']['krb5_conf']['realms']['default_realm_kdcs'] = []
-default['krb5']['krb5_conf']['realms']['default_realm_admin_server'] = ''
+default['krb5']['krb5_conf']['realms']['default_realm_kdcs'] = [node['fqdn']]
+default['krb5']['krb5_conf']['realms']['default_realm_admin_server'] = node['fqdn']
 default['krb5']['krb5_conf']['realms']['realms'] = [default_realm]
 
 # includedir

--- a/recipes/kadmin.rb
+++ b/recipes/kadmin.rb
@@ -3,6 +3,7 @@
 # Recipe:: kadmin
 #
 # Copyright © 2014 Cask Data, Inc.
+# Copyright © 2018 Chris Gianelloni
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,8 +19,6 @@
 #
 
 include_recipe 'krb5::default'
-
-node.default['krb5']['krb5_conf']['realms']['default_realm_admin_server'] = node['fqdn']
 
 node['krb5']['kadmin']['packages'].each do |krb5_package|
   next if node['krb5']['kdc']['packages'].include? krb5_package

--- a/recipes/kdc.rb
+++ b/recipes/kdc.rb
@@ -3,6 +3,7 @@
 # Recipe:: kdc
 #
 # Copyright © 2014 Cask Data, Inc.
+# Copyright © 2018 Chris Gianelloni
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,8 +19,6 @@
 #
 
 include_recipe 'krb5::default'
-
-node.default['krb5']['krb5_conf']['realms']['default_realm_kdcs'] = node['krb5']['krb5_conf']['realms']['default_realm_kdcs'] + [node['fqdn']]
 
 node['krb5']['kdc']['packages'].each do |krb5_package|
   package krb5_package

--- a/recipes/kdc_service.rb
+++ b/recipes/kdc_service.rb
@@ -24,8 +24,8 @@ include_recipe 'krb5::kdc'
 service 'krb5-kdc' do
   service_name node['krb5']['kdc']['service_name']
   action node['krb5']['kdc']['service_actions']
-  subscribes :restart, "template['#{node['krb5']['data_dir']}/kdc.conf']", :delayed if node['krb5']['kdc']['service_actions'].find \
-    { |a| /start/ =~ a }
+  subscribes :restart, "template['#{node['krb5']['data_dir']}/kdc.conf']", :delayed \
+    if [ *node['krb5']['kdc']['service_actions']].find { |a| /start/ =~ a }
 end
 
 service 'kprop' do

--- a/templates/default/krb5.conf.erb
+++ b/templates/default/krb5.conf.erb
@@ -25,18 +25,18 @@ includedir <%= dir %>
 
 <% if @realms %>
 [realms]
- <% unless node['krb5']['krb5_conf']['realms']['default_realm_kdcs'].empty? -%>
- <%= node['krb5']['krb5_conf']['realms']['default_realm'].upcase %> = {
-  <% node['krb5']['krb5_conf']['realms']['default_realm_kdcs'].each do |kdc_server| -%>
+ <% unless @realms['default_realm_kdcs'].empty? -%>
+ <%= @realms['default_realm'].upcase %> = {
+  <% @realms['default_realm_kdcs'].each do |kdc_server| -%>
   kdc = <%= kdc_server %>
   <% end -%>
-  <% unless node['krb5']['krb5_conf']['realms']['default_realm_admin_server'].empty? -%>
-  admin_server = <%= node['krb5']['krb5_conf']['realms']['default_realm_admin_server'] %>
+  <% unless @realms['default_realm_admin_server'].nil? || @realms['default_realm_admin_server'].empty? -%>
+  admin_server = <%= @realms['default_realm_admin_server'] %>
   <% end %>
  }
  <% end -%>
 
- <% node['krb5']['krb5_conf']['realms']['realms'].each do |krb5_realm| -%>
+ <% @realms['realms'].each do |krb5_realm| -%>
  <%= krb5_realm.downcase -%> = <%= krb5_realm.upcase %>
  .<%= krb5_realm.downcase -%> = <%= krb5_realm.upcase %>
  <% end -%>


### PR DESCRIPTION
The way this cookbook originally would default the settings for
kadmind and krb5kdc KDC settings was suboptimal. Instead, we should
use Chef attributes correctly and assume the user is doing the right
thing when using the cookbook. For users running a single kadmind/KDC,
there should be no noticeable difference.

Signed-off-by: Chris Gianelloni <wolf31o2@gmail.com>