### PR TITLE
Support multiple DNS mappings to a realm

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -1,10 +1,14 @@
 driver:
   name: dokken
+  hostname: dokken.local
   privileged: true # because Docker, systemd, and sysctl
   chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
 
 transport:
   name: dokken
+
+verifier:
+  name: inspec
 
 provisioner:
   name: dokken
@@ -15,9 +19,12 @@ platforms:
   driver:
     image: dokken/centos-7
     pid_one_command: /usr/lib/systemd/systemd
-    # This is needed because dcos-spartan.service does "modprobe dummy"
-    volumes:
-    - /lib/modules:/lib/modules:ro
+# - name: ubuntu-16.04
+#   driver:
+#     image: dokken/ubuntu-16.04
+#     pid_one_command: /bin/systemd
+#     intermediate_instructions:
+#       - RUN /usr/bin/apt-get update
 
 suites:
   - name: default
@@ -40,3 +47,24 @@ suites:
   - name: rkerberos
     run_list:
     - recipe[krb5::rkerberos_gem]
+  - name: legacy
+    run_list:
+    - recipe[krb5]
+    attributes:
+      krb5:
+        krb5_conf:
+          realms:
+            realms:
+            - LOCAL
+  - name: multi
+    run_list:
+    - recipe[krb5]
+    attributes:
+      krb5:
+        krb5_conf:
+          realms:
+            realms:
+              LOCAL: local
+              INTERNAL:
+              - internal
+              - ec2.internal

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -95,7 +95,10 @@ default['krb5']['krb5_conf']['libdefaults']['ticket_lifetime'] = '24h'
 default['krb5']['krb5_conf']['realms']['default_realm'] = default_realm
 default['krb5']['krb5_conf']['realms']['default_realm_kdcs'] = [node['fqdn']]
 default['krb5']['krb5_conf']['realms']['default_realm_admin_server'] = node['fqdn']
-default['krb5']['krb5_conf']['realms']['realms'] = [default_realm]
+# This syntax is deprecated, but will still work for defining realms w/ 1:1 mapping to DNS
+# default['krb5']['krb5_conf']['realms']['realms'] = [default_realm]
+# This attribute can be a single value or a list
+default['krb5']['krb5_conf']['realms']['realms'][default_realm] = node['domain']
 
 # includedir
 default['krb5']['krb5_conf']['includedir'] = []

--- a/templates/default/krb5.conf.erb
+++ b/templates/default/krb5.conf.erb
@@ -36,10 +36,19 @@ includedir <%= dir %>
  }
  <% end -%>
 
- <% @realms['realms'].each do |krb5_realm| -%>
+ <% if @realms['realms'].kind_of?(Array) -%>
+  <% @realms['realms'].each do |krb5_realm| -%>
  <%= krb5_realm.downcase -%> = <%= krb5_realm.upcase %>
  .<%= krb5_realm.downcase -%> = <%= krb5_realm.upcase %>
- <% end -%>
+  <% end -%>
+ <% else -%>
+  <% @realms['realms'].each do |realm, dns| -%>
+    <% [*dns].each do |d| -%>
+ <%= d.downcase -%> = <%= realm.upcase %>
+ .<%= d.downcase -%> = <%= realm.upcase %>
+     <% end -%>
+   <% end -%>
+  <% end %>
 <% end %>
 
 <% if @appdefaults %>


### PR DESCRIPTION
Allow for specifying multiple domain mappings to a single realm, while
maintaining backwards compatibility.

Signed-off-by: Chris Gianelloni <wolf31o2@gmail.com>