### PR TITLE
Make authconfig optional

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -74,6 +74,9 @@ override['build-essential']['compile_time'] = true
 # Include ntp recipe?
 default['krb5']['include_ntp'] = true
 
+# Should we perform auth-cnofig or not
+default['krb5']['do_authconfig'] = true
+
 # Client Packages
 default['krb5']['client']['packages'] = node['krb5']['packages']
 default['krb5']['client']['authconfig'] = node['krb5']['authconfig']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -43,5 +43,5 @@ template '/etc/krb5.conf' do
   group 'root'
   mode '0644'
   variables node['krb5']['krb5_conf']
-  notifies :run, 'execute[krb5-authconfig]'
+  notifies :run, 'execute[krb5-authconfig]' if node['krb5']['do_authconfig']
 end


### PR DESCRIPTION
This makes running the auth-config command optional. Fixes #38

Signed-off-by: Chris Gianelloni <wolf31o2@gmail.com>